### PR TITLE
Supporting external logic for restoring / generating custom password

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -43,6 +43,11 @@ export const argv = yargs
                 alias: ['pwd'],
                 describe: dimmed`TemporaryPassword of the users imported`,
                 string: true
+            },
+            passwordModulePath: {
+                alias: ["pwdModule"],
+                describe: dimmed`A module that exports an interface getPwdForUsername(username: String) method, fall back to password parameter if throw`,
+                string: true
             }
         });
     })

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -14,7 +14,7 @@ const orange = chalk.keyword('orange');
 (async () => {
     let spinner = ora({ spinner: 'dots4', hideCursor: true });
     try {
-        const { mode, profile, region, key, secret, userpool, directory, file, password } = await options;
+        const { mode, profile, region, key, secret, userpool, directory, file, password, passwordModulePath } = await options;
 
         // update the config of aws-sdk based on profile/credentials passed
         AWS.config.update({ region });
@@ -35,7 +35,7 @@ const orange = chalk.keyword('orange');
             spinner.succeed(green(`JSON Exported successfully to ${directory}/\n`));
         } else if (mode === 'restore') {
             spinner = spinner.start(orange`Restoring userpool`);
-            await restoreUsers(cognitoISP, userpool, file, password);
+            await restoreUsers(cognitoISP, userpool, file, password, passwordModulePath);
             spinner.succeed(green(`Users imported successfully to ${userpool}\n`));
         } else {
             spinner.fail(red`Mode passed is invalid, please make sure a valid command is passed here.\n`);

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -43,7 +43,7 @@ const searchCognitoRegion = async (_: never, input: string) => {
 };
 
 const verifyOptions = async () => {
-    let { mode, profile, region, key, secret, userpool, directory, file, password } = argv;
+    let { mode, profile, region, key, secret, userpool, directory, file, password, passwordModulePath } = argv;
 
     // choose the mode if not passed through CLI or invalid is passed
     if (!mode || !['restore', 'backup'].includes(mode)) {
@@ -149,7 +149,18 @@ const verifyOptions = async () => {
         file = fileLocation.selected;
     }
 
-    return { mode, profile, region, key, secret, userpool, directory, file, password }
+    if (mode === 'restore' && passwordModulePath) {
+        console.log(passwordModulePath);
+        try {
+            const pwdModule = require(passwordModulePath);
+            if (typeof pwdModule.getPwdForUsername !== 'function') {
+                throw Error(`Cannot find getPwdForUsername(username: String) in password module "${passwordModulePath}".`);
+            };
+        } catch(e) {
+            throw Error(`Cannot load password module path "${passwordModulePath}".`);
+        }
+    }
+    return { mode, profile, region, key, secret, userpool, directory, file, password, passwordModulePath }
 };
 
 

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -150,7 +150,6 @@ const verifyOptions = async () => {
     }
 
     if (mode === 'restore' && passwordModulePath) {
-        console.log(passwordModulePath);
         try {
             const pwdModule = require(passwordModulePath);
             if (typeof pwdModule.getPwdForUsername !== 'function') {


### PR DESCRIPTION
-  For migrating cognito user pool, people might want to do silently for recovering a hashed password / use custom new password policy for each user
- If all users are imported with the same new password (current password parameter's behavior), it is risky for any system

An example usage, create a `pwd_module.js`
```
var exports = module.exports = {};

exports.getPwdForUsername = function(username) {
    // Do custom logic generate password / lookup in a backup for hashed password here
    return 'XXXXX';
}
```
Usage: 
node ./build/cli/cli.js restore --pwdModule {absolute path for pwd_module.js}

