### PR TITLE
Ignore users that already exist in the destination user pool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,15 @@ export const restoreUsers = async (cognito: CognitoISP, UserPoolId: string, file
                 params.TemporaryPassword = password;
             }
             const wrapped = limiter.wrap(async () => cognito.adminCreateUser(params).promise());
-            await wrapped();
+            try {
+               await wrapped();
+            } catch (e) {
+              if (e.message === 'An account with the given email already exists.') {
+                  console.log(`Looks like user ${user.Username} already exists, ignoring.`)
+              } else {
+                throw e;
+              }
+            }
         };
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,7 @@ export const restoreUsers = async (cognito: CognitoISP, UserPoolId: string, file
             try {
                await wrapped();
             } catch (e) {
-              if (e.message === 'An account with the given email already exists.') {
+              if (e.code === 'UsernameExistsException') {
                   console.log(`Looks like user ${user.Username} already exists, ignoring.`)
               } else {
                 throw e;


### PR DESCRIPTION
Sometimes it's handy to restore users into non-empty pool.  Unfortunately your script fails in when there are users already present in the destination pool that have the same user id.

Here is a small patch that will ignore such users and will restore the rest.