### PR TITLE
Fix empty output when there are errors in CI (no tty)

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "inquirer-autocomplete-prompt": "^0.12.2",
     "inquirer-file-path": "^1.0.1",
     "inquirer-select-directory": "^1.2.0",
-    "ora": "^2.1.0",
+    "ora": "^5.2.0",
     "yargs": "^11.0.0"
   }
 }


### PR DESCRIPTION
The old version of the 'ora' library had a bug where all output
(even error messages) would be swallowed when running with no tty
(as is the case when running in, e.g., a CI environment, or even when
just redirecting the output).

See https://github.com/sindresorhus/ora/pull/78

To see this, you can run the following, making sure you do *not* have
any of the AWS env vars set (so the error will be triggered):

```sh
node build/cli/cli.js backup --pool all --use-env-vars --directory tmp &> out
```