### PR TITLE
Support Cognito groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ cbr <command> [options]
 > `--use-env-vars`: Use AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN (optional) as environment variables
 >
 > `--use-ec2-metadata`: Use credentials received from the metadata service on an EC2 instance
+>
+> `--include-groups` `--groups`: Include the Cognito groups a user is included in when backing up/restoring.
 
 ![Image showing CLI Usage](gifs/demo.png "CLI Usage")
 

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -101,6 +101,11 @@ export const argv = yargs
         describe: dimmed`delay in millis between alternate users batch(60) backup, to avoid rate limit error`,
         number: true
     })
+    .option('include-groups', {
+        alias: ['groups'],
+        describe: dimmed`Include the groups that a user is included in.`,
+        type: 'boolean'
+    })
 
     // help
     .help('help', dimmed`Show help`)

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -14,7 +14,7 @@ const orange = chalk.keyword('orange');
 (async () => {
     let spinner = ora({ spinner: 'dots4', hideCursor: true });
     try {
-        const { mode, profile, region, key, secret, userpool, directory, file, password, passwordModulePath, delay, metadata, env} = await options;
+        const { mode, profile, region, key, secret, userpool, directory, file, password, passwordModulePath, delay, metadata, env, groups } = await options;
 
         // update the config of aws-sdk based on profile/credentials passed
         AWS.config.update({ region });
@@ -29,13 +29,13 @@ const orange = chalk.keyword('orange');
             AWS.config.credentials = new AWS.EnvironmentCredentials('AWS');
         } else if (metadata) {
             AWS.config.credentials = new AWS.EC2MetadataCredentials({});
-        } 
+        }
 
         const cognitoISP = new AWS.CognitoIdentityServiceProvider();
 
         if (mode === 'backup') {
             spinner = spinner.start(orange`Backing up userpool`);
-            await backupUsers(cognitoISP, userpool, directory, delay);
+            await backupUsers(cognitoISP, userpool, directory, delay, groups);
             spinner.succeed(green(`JSON Exported successfully to ${directory}/\n`));
         } else if (mode === 'restore') {
             spinner = spinner.start(orange`Restoring userpool`);

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -39,7 +39,7 @@ const orange = chalk.keyword('orange');
             spinner.succeed(green(`JSON Exported successfully to ${directory}/\n`));
         } else if (mode === 'restore') {
             spinner = spinner.start(orange`Restoring userpool`);
-            await restoreUsers(cognitoISP, userpool, file, password, passwordModulePath);
+            await restoreUsers(cognitoISP, userpool, file, password, passwordModulePath, groups);
             spinner.succeed(green(`Users imported successfully to ${userpool}\n`));
         } else {
             spinner.fail(red`Mode passed is invalid, please make sure a valid command is passed here.\n`);

--- a/src/cli/options.ts
+++ b/src/cli/options.ts
@@ -32,7 +32,7 @@ const searchCognitoRegion = async (_: never, input: string) => {
 };
 
 const verifyOptions = async () => {
-    let { mode, profile, region, key, secret, userpool, directory, file, password, passwordModulePath, delay, metadata, env } = argv;
+    let { mode, profile, region, key, secret, userpool, directory, file, password, passwordModulePath, delay, metadata, env, groups } = argv;
 
     // choose the mode if not passed through CLI or invalid is passed
     if (!mode || !['restore', 'backup'].includes(mode)) {
@@ -173,7 +173,7 @@ const verifyOptions = async () => {
             throw Error(`Cannot load password module path "${passwordModulePath}".`);
         }
     }
-    return { mode, profile, region, key, secret, userpool, directory, file, password, passwordModulePath, delay, metadata, env }
+    return { mode, profile, region, key, secret, userpool, directory, file, password, passwordModulePath, delay, metadata, env, groups }
 };
 
 


### PR DESCRIPTION
Related to https://github.com/rahulpsd18/cognito-backup-restore/issues/10

Adds the option to include the Cognito groups that a user is included in when backing up/restoring.

Other changes:

- Promisify the `restoreUsers` function so that awaiting it works correctly here: https://github.com/rahulpsd18/cognito-backup-restore/blob/master/src/cli/cli.ts#L42